### PR TITLE
Fix fallback color in location card

### DIFF
--- a/components/location-card-detailed.tsx
+++ b/components/location-card-detailed.tsx
@@ -175,7 +175,7 @@ export function LocationCardDetailed({
             disabled={isLoading}
             className="w-full h-12 text-lg font-medium relative overflow-hidden"
             style={{
-              backgroundColor: isLoading ? "#gray-400" : location.theme.primary,
+              backgroundColor: isLoading ? "#9ca3af" : location.theme.primary,
               borderColor: location.theme.primary,
             }}
           >


### PR DESCRIPTION
## Summary
- update fallback color in `location-card-detailed` to use Tailwind value

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a2870c0dc83209a02eb98d037a344